### PR TITLE
Add support for direnv .envrc file format

### DIFF
--- a/modules/core/src/main/java/net/ashald/envfile/providers/dotenv/DotEnvFileParser.java
+++ b/modules/core/src/main/java/net/ashald/envfile/providers/dotenv/DotEnvFileParser.java
@@ -31,7 +31,7 @@ public class DotEnvFileParser extends AbstractEnvVarsProvider {
                 if (!strippedLine.startsWith("#") && strippedLine.contains("=")) {
                     String[] tokens = strippedLine.split("=", 2);
                     String key = tokens[0];
-                    if (key.startsWith("export ") {
+                    if (key.startsWith("export ")) {
                         key = key.substring(7);
                     }
                     String value = trim(tokens[1]);

--- a/modules/core/src/main/java/net/ashald/envfile/providers/dotenv/DotEnvFileParser.java
+++ b/modules/core/src/main/java/net/ashald/envfile/providers/dotenv/DotEnvFileParser.java
@@ -31,6 +31,9 @@ public class DotEnvFileParser extends AbstractEnvVarsProvider {
                 if (!strippedLine.startsWith("#") && strippedLine.contains("=")) {
                     String[] tokens = strippedLine.split("=", 2);
                     String key = tokens[0];
+                    if (key.startsWith("export ") {
+                        key = key.substring(7);
+                    }
                     String value = trim(tokens[1]);
                     result.put(key, value);
                 }


### PR DESCRIPTION
.envrc files used by direnv use `export x=y` format for their entries. This patch strips the `export` allowing the plugin to use direnv files directly.